### PR TITLE
Feat  add union and mixed types

### DIFF
--- a/.changeset/mighty-oranges-pretend.md
+++ b/.changeset/mighty-oranges-pretend.md
@@ -1,0 +1,5 @@
+---
+"monarch-orm": minor
+---
+
+add union and mixed types

--- a/README.md
+++ b/README.md
@@ -443,3 +443,33 @@ await collections.notifications.insert().values({ notification: {
   },
 } }).exec();
 ```
+
+
+### Union
+
+The `union()` type allows you to define a field that can accept multiple different types. It's useful when a field can legitimately contain values of different types. Each type provided to `union()` acts as a possible variant for the field.
+
+```typescript - union()
+
+const MilfSchema = createSchema("milf", {
+  phoneOrEmail: union(string(), number()),
+});
+
+// Output Type : { 
+//   phoneOrEmail: string | number
+// }
+```
+
+
+### Mixed
+
+### Mixed
+
+The `mixed()` type allows you to define a field that can accept any type of value. This is useful when you need maximum flexibility for a field's contents. However, use it sparingly as it bypasses TypeScript's type checking.
+
+```typescript - mixed()
+
+const AnythingSchema = createSchema("help", {
+  anything: mixed(),
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { array } from "./types/array";
 export { boolean } from "./types/boolean";
 export { createdAtDate, date, dateString, updatedAtDate } from "./types/date";
 export { literal } from "./types/literal";
+export { mixed } from "./types/mixed";
 export { number } from "./types/number";
 export { object } from "./types/object";
 export { objectId } from "./types/objectId";
@@ -16,6 +17,7 @@ export { taggedUnion } from "./types/tagged-union";
 export { tuple } from "./types/tuple";
 export { MonarchType, type } from "./types/type";
 export { InferTypeInput, InferTypeOutput } from "./types/type-helpers";
+export { union } from "./types/union";
 export {
   generateObjectId,
   isValidObjectId,

--- a/src/types/mixed.ts
+++ b/src/types/mixed.ts
@@ -1,0 +1,11 @@
+import { MonarchType } from "./type";
+
+export const mixed = () => new MonarchMixed();
+
+export class MonarchMixed extends MonarchType<unknown, unknown> {
+  constructor() {
+    super((input) => {
+      return input;
+    });
+  }
+}

--- a/src/types/type-helpers.ts
+++ b/src/types/type-helpers.ts
@@ -38,6 +38,14 @@ export type InferTypeTupleOutput<
   [K in keyof T]: InferTypeOutput<T[K]>;
 };
 
+export type InferTypeUnionInput<
+  T extends [AnyMonarchType, ...AnyMonarchType[]],
+> = InferTypeInput<T[number]>;
+
+export type InferTypeUnionOutput<
+  T extends [AnyMonarchType, ...AnyMonarchType[]],
+> = InferTypeOutput<T[number]>;
+
 export type InferTypeTaggedUnionInput<
   T extends Record<string, AnyMonarchType>,
 > = {

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,0 +1,34 @@
+import { MonarchParseError } from "../errors";
+import { type AnyMonarchType, MonarchType } from "./type";
+import type { InferTypeUnionInput, InferTypeUnionOutput } from "./type-helpers";
+
+export const union = <T extends [AnyMonarchType, ...AnyMonarchType[]]>(
+  ...variants: T
+) => new MonarchUnion(variants);
+
+export class MonarchUnion<
+  T extends [AnyMonarchType, ...AnyMonarchType[]],
+> extends MonarchType<InferTypeUnionInput<T>, InferTypeUnionOutput<T>> {
+  constructor(variants: T) {
+    super((input) => {
+      for (const [index, type] of variants.entries()) {
+        try {
+          return type._parser(input);
+        } catch (error) {
+          if (error instanceof MonarchParseError) {
+            if (index === variants.length - 1) {
+              throw new MonarchParseError(
+                `no matching variant found for union type: ${error.message}`,
+              );
+            }
+            continue;
+          }
+          throw error;
+        }
+      }
+      throw new MonarchParseError(
+        `expected one of union variants but received '${typeof input}'`,
+      );
+    });
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for union and mixed types in the "monarch-orm" package, enhancing data modeling flexibility.
	- Added new exports for `mixed` and `union` types, expanding available type utilities.
	- Implemented `MonarchMixed` and `MonarchUnion` classes for better handling of mixed and union types.

- **Bug Fixes**
	- Enhanced error handling for type conflicts in union and mixed types.

- **Tests**
	- Added tests for the new `union` and `mixed` types to ensure proper validation and transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->